### PR TITLE
(fix) : add missing code block markdown

### DIFF
--- a/LEARN.md
+++ b/LEARN.md
@@ -63,6 +63,7 @@ def add_transaction(self, sender, recipient, amount):
 
 A hash is a fingerprint of some data. For example, if we pass “hello, world” to SHA-256 (a hashing algorithm), we might get something like 0xd34db33f. Since no two blocks will have the exact same transactions, we can use SHA-256 to create a unique identifier for the block. From now on, we can reference a certain block by using this ID called block hash.
 
+```
 def compute_hash(self, block):
 
     json_block = json.dumps(block, sort_keys=True).encode()
@@ -70,6 +71,7 @@ def compute_hash(self, block):
     curhash = sha256(json_block).hexdigest()
 
     return curhash
+```
 
 We’re getting a JSON representation of the data in the block and returning the hash of the JSON block.
 


### PR DESCRIPTION
add missing code block markdown which was causing formatting issue

## Before
<img width="1103" alt="Screenshot 2022-01-12 at 6 44 37 PM" src="https://user-images.githubusercontent.com/18427383/149147469-4121071f-fd29-4131-8491-624691cbea1d.png">

## 
<img width="1161" alt="Screenshot 2022-01-12 at 6 48 41 PM" src="https://user-images.githubusercontent.com/18427383/149147802-cabbfaa7-f09c-4c28-9f2b-41670c4a2922.png">
After
